### PR TITLE
Add diagram generation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,12 +159,12 @@ graph TD
 
 #### Gerando o diagrama com D2
 
-O diagrama acima é descrito em `docs/architecture.d2`. Para gerar as versões GIF e
-SVG, instale o [D2 CLI](https://d2lang.com/) e execute:
+O diagrama acima é descrito em `docs/diagrams/architecture.d2`. Para gerar as versões SVG e GIF,
+instale o [D2 CLI](https://d2lang.com/) e execute:
 
 ```bash
-d2 docs/architecture.d2 docs/architecture.svg
-d2 --format=gif docs/architecture.d2 docs/architecture.gif
+d2 docs/diagrams/architecture.d2 docs/diagrams/architecture.svg
+d2 --animate-interval 1000 docs/diagrams/architecture.d2 docs/diagrams/architecture.gif
 ```
 
 ## Injeção de Dependências

--- a/README_en.md
+++ b/README_en.md
@@ -159,12 +159,12 @@ graph TD
 
 #### Generating the diagram with D2
 
-The diagram above is described in `docs/architecture.d2`. To create SVG and GIF
+The diagram above is described in `docs/diagrams/architecture.d2`. To create SVG and GIF
 versions, install the [D2 CLI](https://d2lang.com/) and run:
 
 ```bash
-d2 docs/architecture.d2 docs/architecture.svg
-d2 --format=gif docs/architecture.d2 docs/architecture.gif
+d2 docs/diagrams/architecture.d2 docs/diagrams/architecture.svg
+d2 --animate-interval 1000 docs/diagrams/architecture.d2 docs/diagrams/architecture.gif
 ```
 
 ## Dependency Injection


### PR DESCRIPTION
## Summary
- describe regenerating diagrams using d2 CLI in README and README_en
- track empty docs/diagrams directory for storing .d2 and output files

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aed6fd3a8833284c10f496124c42e