### PR TITLE
Fix gitignore for docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,5 +42,7 @@ app.*.map.json
 /android/app/profile
 /android/app/release
 
-*.md
+/*.md
 !README.md
+!README_en.md
+!docs/**/*.md


### PR DESCRIPTION
## Summary
- allow markdown files under docs directory and other subfolders by adjusting the `.gitignore`

## Testing
- `melos run analyze` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aed707a3483329fc7c33be8afdcf2